### PR TITLE
Add option to set background grey level

### DIFF
--- a/common.go
+++ b/common.go
@@ -25,7 +25,6 @@ import (
 )
 
 const (
-	bg        = 33    // Gray level for visualization backgrounds
 	grid      = 45    // Gray level for grid lines
 	opaque    = 255   // Alpha component of an opaque color value
 	saturated = 255   // Saturated 8-bit color value
@@ -102,9 +101,9 @@ func getRGBA(i *image.RGBA, x int, y int) *color.RGBA {
 }
 
 // Utility function for setting up a visualization canvas.
-func initializeVisualization(width int, height int) *image.RGBA {
+func initializeVisualization(width int, height int, bg int) *image.RGBA {
 	vis := image.NewRGBA(image.Rect(0, 0, width, height))
-	background := color.RGBA{bg, bg, bg, opaque}
+	background := color.RGBA{uint8(bg), uint8(bg), uint8(bg), opaque}
 	draw.Draw(vis, vis.Bounds(), &image.Uniform{background}, image.ZP, draw.Src)
 	return vis
 }

--- a/error_stack.go
+++ b/error_stack.go
@@ -23,15 +23,16 @@ import (
 )
 
 type errorStack struct {
-	w int           // Width of the visualization
-	h int           // Height of the visualization
-	n map[int16]int // Event counts by exit status code
-	σ float64       // Total count of failed events
+	w  int           // Width of the visualization
+	h  int           // Height of the visualization
+	bg int           // Background grey level
+	n  map[int16]int // Event counts by exit status code
+	σ  float64       // Total count of failed events
 }
 
 // NewErrorStack returns an error-stack-visualization generator.
-func NewErrorStack(width int, height int) Visualizer {
-	return &errorStack{width, height, make(map[int16]int), 0}
+func NewErrorStack(width int, height int, bg int) Visualizer {
+	return &errorStack{width, height, bg, make(map[int16]int), 0}
 }
 
 // Record accepts an EventData pointer and plots it onto the visualization.
@@ -51,7 +52,7 @@ func (v *errorStack) Record(e *EventData) {
 func (v *errorStack) Render() image.Image {
 
 	// Initialize our image canvas.
-	vis := initializeVisualization(v.w, v.h)
+	vis := initializeVisualization(v.w, v.h, v.bg)
 
 	// Draw the stack, giving each failure type a different color and scaling
 	// the overall stack to fill the image canvas such that each failure case

--- a/histogram.go
+++ b/histogram.go
@@ -26,16 +26,18 @@ import (
 type histogram struct {
 	w     int     // Width of the visualization
 	h     int     // Height of the visualization
+	bg    int     // Background grey level
 	yLog2 float64 // Number of pixels over which elapsed times double
 	pass  []int   // Counts of successful events by x-axis position
 	fail  []int   // Counts of failed events by x-axis position
 }
 
 // NewHistogram returns a histogram-visualization generator.
-func NewHistogram(width int, height int, yLog2 float64) Visualizer {
+func NewHistogram(width int, height int, bg int, yLog2 float64) Visualizer {
 	return &histogram{
 		width,
 		height,
+		bg,
 		yLog2,
 		make([]int, width),
 		make([]int, width)}
@@ -66,7 +68,7 @@ func (v *histogram) Record(e *EventData) {
 func (v *histogram) Render() image.Image {
 
 	// Initialize our image canvas and grid.
-	vis := initializeVisualization(v.w, v.h)
+	vis := initializeVisualization(v.w, v.h, v.bg)
 	v.drawGrid(vis)
 
 	// Find the highest point of the histogram to normalize the height of the

--- a/perspective-server/main.go
+++ b/perspective-server/main.go
@@ -52,6 +52,7 @@ type options struct {
 	yLog2        float64 // Number of pixels over which elapsed times double.
 	w            int     // Visualization width, in pixels.
 	h            int     // Visualization height, in pixels.
+	bg           int     // Graph background color.
 	colors       int     // The number of color steps before saturation.
 	feed         string  // Input feed name.
 }
@@ -59,47 +60,48 @@ type options struct {
 func init() {
 
 	handlers["vis-error-stack"] = func(out http.ResponseWriter, r *options) {
-		visualize(perspective.NewErrorStack(r.w, r.h), out, r)
+		visualize(perspective.NewErrorStack(r.w, r.h, r.bg), out, r)
 	}
 
 	handlers["vis-histogram"] = func(out http.ResponseWriter, r *options) {
-		visualize(perspective.NewHistogram(r.w, r.h, r.yLog2), out, r)
+		visualize(perspective.NewHistogram(r.w, r.h, r.bg, r.yLog2), out, r)
 	}
 
 	handlers["vis-ribbon"] = func(out http.ResponseWriter, r *options) {
-		visualize(perspective.NewRibbon(r.w, r.h, r.tA, r.tΩ), out, r)
+		visualize(perspective.NewRibbon(r.w, r.h, r.bg, r.tA, r.tΩ), out, r)
 	}
 
 	handlers["vis-rolling-stack"] = func(out http.ResponseWriter, r *options) {
-		visualize(perspective.NewRollingStack(r.w, r.h, r.tA, r.tΩ), out, r)
+		visualize(
+			perspective.NewRollingStack(r.w, r.h, r.bg, r.tA, r.tΩ), out, r)
 	}
 
 	handlers["vis-scatter"] = func(out http.ResponseWriter, r *options) {
 		visualize(
 			perspective.NewScatter(
-				r.w, r.h, r.tA, r.tΩ, r.yLog2, r.colors, r.xGrid),
+				r.w, r.h, r.bg, r.tA, r.tΩ, r.yLog2, r.colors, r.xGrid),
 			out,
 			r)
 	}
 
 	handlers["vis-status-stack"] = func(out http.ResponseWriter, r *options) {
-		visualize(perspective.NewStatusStack(r.w, r.h), out, r)
+		visualize(perspective.NewStatusStack(r.w, r.h, r.bg), out, r)
 	}
 
 	handlers["vis-sweep"] = func(out http.ResponseWriter, r *options) {
 		visualize(
 			perspective.NewSweep(
-				r.w, r.h, r.tA, r.tΩ, r.yLog2, r.colors, r.xGrid),
+				r.w, r.h, r.bg, r.tA, r.tΩ, r.yLog2, r.colors, r.xGrid),
 			out,
 			r)
 	}
 
 	handlers["vis-wave"] = func(out http.ResponseWriter, r *options) {
-		visualize(perspective.NewWave(r.w, r.h, r.tA, r.tΩ), out, r)
+		visualize(perspective.NewWave(r.w, r.h, r.bg, r.tA, r.tΩ), out, r)
 	}
 
 	handlers["vis-wave-sorted"] = func(out http.ResponseWriter, r *options) {
-		visualize(perspective.NewSortedWave(r.w, r.h, r.tA, r.tΩ), out, r)
+		visualize(perspective.NewSortedWave(r.w, r.h, r.bg, r.tA, r.tΩ), out, r)
 	}
 }
 
@@ -303,6 +305,7 @@ func responder(response http.ResponseWriter, request *http.Request) {
 		f64Opt(values, "run-time-scale", 16),
 		intOpt(values, "width", 256),
 		intOpt(values, "height", 256),
+		intOpt(values, "bg", 33),
 		intOpt(values, "color-steps", 1),
 		strOpt(values, "feed", "")}
 

--- a/ribbon.go
+++ b/ribbon.go
@@ -25,6 +25,7 @@ import (
 type ribbon struct {
 	w    int     // Width of the visualization
 	h    int     // Height of the visualization
+	bg   int     // Background grey level
 	tA   float64 // Lower limit of time range to be visualized
 	tτ   float64 // Length of time range to be visualized
 	pass []int   // Successful events by x-axis position
@@ -36,7 +37,12 @@ type ribbon struct {
 }
 
 // NewRibbon returns a ribbon-visualization generator.
-func NewRibbon(width int, height int, minTime int, maxTime int) Visualizer {
+func NewRibbon(
+	width int,
+	height int,
+	bg int,
+	minTime int,
+	maxTime int) Visualizer {
 
 	// Max counts are initialized to 1 instead of 0 to avoid division-by-zero
 	// issues with feeds which do not contain examples of all three of
@@ -44,6 +50,7 @@ func NewRibbon(width int, height int, minTime int, maxTime int) Visualizer {
 	return &ribbon{
 		width,
 		height,
+		bg,
 		float64(minTime),
 		float64(maxTime - minTime),
 		make([]int, width),
@@ -80,7 +87,7 @@ func (v *ribbon) Record(e *EventData) {
 func (v *ribbon) Render() image.Image {
 
 	// Initialize our canvas.
-	vis := initializeVisualization(v.w, v.h)
+	vis := initializeVisualization(v.w, v.h, v.bg)
 
 	// Draw the ribbon. The ribbon's display is a simple representation of the
 	// number of passed and failed events which occurred within each pixel's
@@ -96,7 +103,7 @@ func (v *ribbon) Render() image.Image {
 	for x := 0; x < v.w; x++ {
 		r := saturated * float64(v.fail[x]) / fMax
 		b := saturated * float64(v.pass[x]) / pMax
-		w := bg + (saturated-bg)*float64(v.open[x])/oMax
+		w := float64(v.bg) + float64(saturated-v.bg)*float64(v.open[x])/oMax
 		for y := 0; y < v.h; y++ {
 			c := getRGBA(vis, x, y)
 			c.R = uint8(math.Min(saturated, w+r*float64(y)/h))

--- a/rolling_stack.go
+++ b/rolling_stack.go
@@ -25,6 +25,7 @@ import (
 type rollingStack struct {
 	w  int             // Width of the visualization
 	h  int             // Height of the visualization
+	bg int             // Background grey level
 	tA float64         // Lower limit of time range to be visualized
 	tτ float64         // Length of time range to be visualized
 	n  map[int16][]int // Event counts by status and x-axis position
@@ -35,12 +36,14 @@ type rollingStack struct {
 func NewRollingStack(
 	width int,
 	height int,
+	bg int,
 	minTime int,
 	maxTime int) Visualizer {
 
 	return &rollingStack{
 		width,
 		height,
+		bg,
 		float64(minTime),
 		float64(maxTime - minTime),
 		make(map[int16][]int),
@@ -67,7 +70,7 @@ func (v *rollingStack) Record(e *EventData) {
 func (v *rollingStack) Render() image.Image {
 
 	// Initialize our image canvas.
-	vis := initializeVisualization(v.w, v.h)
+	vis := initializeVisualization(v.w, v.h, v.bg)
 
 	// Draw the rolling stack, giving each failure type a different color and
 	// scaling the height of the visualization to normalize for the overall

--- a/scatter.go
+++ b/scatter.go
@@ -36,6 +36,7 @@ type scatter struct {
 func NewScatter(
 	width int,
 	height int,
+	bg int,
 	minTime int,
 	maxTime int,
 	yLog2 float64,
@@ -45,7 +46,7 @@ func NewScatter(
 	return (&scatter{
 		width,
 		height,
-		initializeVisualization(width, height),
+		initializeVisualization(width, height, bg),
 		float64(minTime),
 		float64(maxTime - minTime),
 		float64(yLog2),

--- a/status_stack.go
+++ b/status_stack.go
@@ -23,15 +23,16 @@ import (
 )
 
 type statusStack struct {
-	w int           // Width of the visualization
-	h int           // Height of the visualization
-	n map[int16]int // Event counts by exit status code
-	σ float64       // Total count of recorded events
+	w  int           // Width of the visualization
+	h  int           // Height of the visualization
+	bg int           // Background grey level
+	n  map[int16]int // Event counts by exit status code
+	σ  float64       // Total count of recorded events
 }
 
 // NewStatusStack returns a status-stack-visualization generator.
-func NewStatusStack(width int, height int) Visualizer {
-	return &statusStack{width, height, make(map[int16]int), 0}
+func NewStatusStack(width int, height int, bg int) Visualizer {
+	return &statusStack{width, height, bg, make(map[int16]int), 0}
 }
 
 // Record accepts an EventData pointer and plots it onto the visualization.
@@ -51,7 +52,7 @@ func (v *statusStack) Record(e *EventData) {
 func (v *statusStack) Render() image.Image {
 
 	// Initialize our image canvas.
-	vis := initializeVisualization(v.w, v.h)
+	vis := initializeVisualization(v.w, v.h, v.bg)
 
 	// Draw the stack, giving each failure type a different color and scaling
 	// the overall stack stuck that each failure case occupies space

--- a/sweep.go
+++ b/sweep.go
@@ -32,10 +32,11 @@ type sweep struct {
 	cΔ    float64     // Increment for color channel value increases
 }
 
-// NewSweep returns an sweep-visualization generator.
+// NewSweep returns a sweep-visualization generator.
 func NewSweep(
 	width int,
 	height int,
+	bg int,
 	minTime int,
 	maxTime int,
 	yLog2 float64,
@@ -45,7 +46,7 @@ func NewSweep(
 	return (&sweep{
 		width,
 		height,
-		initializeVisualization(width, height),
+		initializeVisualization(width, height, bg),
 		float64(minTime),
 		float64(maxTime),
 		float64(yLog2),

--- a/wave.go
+++ b/wave.go
@@ -26,6 +26,7 @@ import (
 type wave struct {
 	w   int          // Width of the visualization
 	h   int          // Height of the visualization
+	bg  int          // Background grey level.
 	tA  float64      // Lower limit of time range to be visualized
 	tΩ  float64      // Upper limit of time range to be visualized
 	vis *image.RGBA  // Visualization canvas
@@ -35,13 +36,19 @@ type wave struct {
 }
 
 // NewWave returns a wave-visualization generator.
-func NewWave(width int, height int, minTime int, maxTime int) Visualizer {
+func NewWave(
+	width int,
+	height int,
+	bg int,
+	minTime int,
+	maxTime int) Visualizer {
 	return &wave{
 		width,
 		height,
+		bg,
 		float64(minTime),
 		float64(maxTime),
-		initializeVisualization(width, height),
+		initializeVisualization(width, height, bg),
 		0,
 		[]*EventData{},
 		[]*EventData{}}
@@ -87,9 +94,9 @@ func (v *wave) Record(e *EventData) {
 			p := v.p[len(v.p)-i-1]
 			Δ := saturated * float64(e.Start-p.Start) / float64(p.Run+1)
 			c := color.RGBA{
-				uint8(math.Min(saturated, float64(bg)+Δ/4)),
-				uint8(math.Min(saturated, float64(bg)+Δ/4)),
-				uint8(math.Min(saturated, float64(bg)+Δ)),
+				uint8(math.Min(saturated, float64(v.bg)+Δ/4)),
+				uint8(math.Min(saturated, float64(v.bg)+Δ/4)),
+				uint8(math.Min(saturated, float64(v.bg)+Δ)),
 				opaque}
 			yPʹ := yP + 1
 			for ; yP < yPʹ; yP++ {
@@ -100,9 +107,9 @@ func (v *wave) Record(e *EventData) {
 			f := v.f[len(v.f)-i-1]
 			Δ := saturated * float64(e.Start-f.Start) / float64(f.Run+1)
 			c := color.RGBA{
-				uint8(math.Min(saturated, float64(bg)+Δ)),
-				uint8(math.Min(saturated, float64(bg)+Δ/4)),
-				uint8(math.Min(saturated, float64(bg)+Δ/4)),
+				uint8(math.Min(saturated, float64(v.bg)+Δ)),
+				uint8(math.Min(saturated, float64(v.bg)+Δ/4)),
+				uint8(math.Min(saturated, float64(v.bg)+Δ/4)),
 				opaque}
 			yFʹ := yF + 1
 			for ; yF < yFʹ; yF++ {

--- a/wave_sorted.go
+++ b/wave_sorted.go
@@ -27,6 +27,7 @@ import (
 type sortedWave struct {
 	w   int          // Width of the visualization
 	h   int          // Height of the visualization
+	bg  int          // Background grey level
 	tA  float64      // Lower limit of time range to be visualized
 	tΩ  float64      // Upper limit of time range to be visualized
 	vis *image.RGBA  // Visualization canvas
@@ -36,14 +37,20 @@ type sortedWave struct {
 }
 
 // NewSortedWave returns a wave-sorted-visualization generator.
-func NewSortedWave(width int, height int, minTime int, maxTime int) Visualizer {
+func NewSortedWave(
+	width int,
+	height int,
+	bg int,
+	minTime int,
+	maxTime int) Visualizer {
 
 	return &sortedWave{
 		width,
 		height,
+		bg,
 		float64(minTime),
 		float64(maxTime),
-		initializeVisualization(width, height),
+		initializeVisualization(width, height, bg),
 		0,
 		[]*EventData{},
 		[]*EventData{}}
@@ -95,9 +102,9 @@ func (v *sortedWave) Record(e *EventData) {
 		for _, prog := range points {
 			Δ := saturated * prog
 			c := color.RGBA{
-				uint8(math.Min(saturated, float64(bg)+Δ/4)),
-				uint8(math.Min(saturated, float64(bg)+Δ/4)),
-				uint8(math.Min(saturated, float64(bg)+Δ)),
+				uint8(math.Min(saturated, float64(v.bg)+Δ/4)),
+				uint8(math.Min(saturated, float64(v.bg)+Δ/4)),
+				uint8(math.Min(saturated, float64(v.bg)+Δ)),
 				opaque}
 			yPʹ := yP + 1
 			for ; yP < yPʹ; yP++ {
@@ -113,9 +120,9 @@ func (v *sortedWave) Record(e *EventData) {
 		for _, prog := range points {
 			Δ := saturated * prog
 			c := color.RGBA{
-				uint8(math.Min(saturated, float64(bg)+Δ)),
-				uint8(math.Min(saturated, float64(bg)+Δ/4)),
-				uint8(math.Min(saturated, float64(bg)+Δ/4)),
+				uint8(math.Min(saturated, float64(v.bg)+Δ)),
+				uint8(math.Min(saturated, float64(v.bg)+Δ/4)),
+				uint8(math.Min(saturated, float64(v.bg)+Δ/4)),
 				opaque}
 			yFʹ := yF + 1
 			for ; yF < yFʹ; yF++ {


### PR DESCRIPTION
Add "bg" option for Perspective server so that the background grey level
can be set by the user to adjust image contrast. If not specified, the
default value is set to the previous hard-coded value, so consumers of
this service will not be affected.

Addresses https://github.com/cparo/perspective/issues/25